### PR TITLE
Use pyQgis to check Qgis version

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ List all plugins installed :
 
 ```bash
 $ qgis-plugin-manager list
-/usr/lib/cgi-bin/qgis_mapserv.fcgi is not found, not possible to determine QGIS version. Try QGIS_EXEC_PATH
 QGIS server version 3.19.0
 List all plugins in /home/etienne/dev/qgis/server_plugin
 

--- a/qgis_plugin_manager/utils.py
+++ b/qgis_plugin_manager/utils.py
@@ -37,40 +37,15 @@ def parse_version(version: str) -> Union[None, list]:
     return version
 
 
-def parse_ldd(command_output: str):
-    if isinstance(command_output, str):
-        command_output = command_output.split('\n')
-
-    for line in command_output:
-        # line = [i.strip() for i in line.split("=>")]
-
-        if isinstance(line, list):
-            line = line[0]
-
-        exp = re.search(r"\d+.\d+.\d+", line)
-        if exp:
-            return exp.group()
-
-    return None
-
-
 def qgis_server_version():
-    """ Try to guess the QGIS Server version. """
-    # Using ldd :(
-    exec_path = os.getenv('QGIS_EXEC_PATH')
-    if not exec_path:
-        exec_path = "/usr/lib/cgi-bin/qgis_mapserv.fcgi"
+    """ Try to guess the QGIS Server version. 
+    
+        On linux distro, qgis python packages are installed at standard location
+        in /usr/lib/python3/dist-packages
+    """
+    try:
+        from qgis.core import Qgis
+        return Qgis.QGIS_VERSION.split('-')[0]            
+    except ImportError:
+        print(f"Cannot check version with pyQgis, check your qgis installation or your PYTHONPATH")
 
-    output = subprocess.run(["ls", exec_path], capture_output=True)
-
-    if output.returncode != 0:
-        print(f"{exec_path} is not found, not possible to determine QGIS version. Try QGIS_EXEC_PATH")
-        return None
-
-    output = subprocess.run(
-        ["ldd", exec_path],
-        capture_output=True,
-        text=True,
-    )
-    output = [i for i in output.stdout.split('\n') if 'qgis' in i]
-    return parse_ldd(output)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,29 +1,9 @@
 import unittest
 
-from qgis_plugin_manager.utils import parse_ldd, parse_version
+from qgis_plugin_manager.utils import parse_version
 
 
 class TestUtils(unittest.TestCase):
-
-    def test_qgis_server_version(self):
-        """ Trying the LDD command to know QGIS Server version. """
-        output = (
-            "	libqgis_server.so.3.10.4 => /lib/libqgis_server.so.3.10.4 (0x00007f6c76269000)\n"
-            "	libqgis_core.so.3.10.4 => /lib/libqgis_core.so.3.10.4 (0x00007f6c74fd4000)"
-        )
-        self.assertEqual('3.10.4', parse_ldd(output))
-
-        output = (
-            "	libqgis_server.so.3.4.4 => /lib/libqgis_server.so.3.4.4 (0x00007f6c76269000)\n"
-            "	libqgis_core.so.3.4.4 => /lib/libqgis_core.so.3.4.4 (0x00007f6c74fd4000)"
-        )
-        self.assertEqual('3.4.4', parse_ldd(output))
-
-        output = (
-            "libqgis_server.so.3.16.6 => /home/etienne/dev/app/qgis-stable/lib/libqgis_server.so.3.16.6 (0x00007f6b2dd30000)\n"
-            "libqgis_core.so.3.16.6 => /home/etienne/dev/app/qgis-stable/lib/libqgis_core.so.3.16.6 (0x00007f6b2b879000)"
-        )
-        self.assertEqual('3.16.6', parse_ldd(output))
 
     def test_version(self):
         self.assertListEqual([3, 10, 0], parse_version("3.10"))


### PR DESCRIPTION
Qgis python packages are installed in standard location: it possible to `import qgis` like any installed python packages`.

From this, it is straightforward to check the Installed Qgis (server) version with `Qgis.QGIS_VERSION`.
 